### PR TITLE
Feat: OAuth2  를 이용하여 kakao 로 로그인 연동하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     testImplementation 'org.springframework.security:spring-security-test'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,4 +2,24 @@ spring:
   application:
     name: websocket-chat
 
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: d427c0410a48c5140c17e1a48d437148
+            client-secret: JRhzxNUj6SVWcbiaoMqdNhaAoqFEUuQO
+            scope:
+              - profile_nickname
+            redirect-uri: "http://localhost:8080/login/oauth2/code/kakao"
+            client-name: kakao
+            authorization-grant-type: authorization_code
+            client-authentication-method: client_secret_post
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
 


### PR DESCRIPTION
REST API KEY : cleint-id

보안 : client-secret

동의 항목 : profile_nickname

플랫폼 : web - Site Domain , Redirect-Uri 설정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능  
  - OAuth2 인증 지원과 카카오 소셜 로그인 기능이 추가되어, 사용자가 보다 안전하고 편리하게 서비스를 이용할 수 있습니다.  
  - 이번 업데이트로 전반적인 보안 체계가 강화되어 사용자 경험의 안정성이 향상됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->