### PR TITLE
Feat: kakao 회원가입 기능 연동

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,10 +28,12 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     testImplementation 'org.springframework.security:spring-security-test'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    runtimeOnly 'com.mysql:mysql-connector-j'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/src/main/java/fastcampus/websocketchat/controller/StompChatController.java
+++ b/src/main/java/fastcampus/websocketchat/controller/StompChatController.java
@@ -1,9 +1,13 @@
 package fastcampus.websocketchat.controller;
 
+import fastcampus.websocketchat.dto.ChatMessage;
+import java.security.Principal;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.stereotype.Controller;
 
 @Controller
@@ -12,9 +16,11 @@ public class StompChatController {
 
     @MessageMapping("/chats") // /pub/chats
     @SendTo("/sub/chats")
-    public String handleMessage(@Payload String message){
-        log.info("received: {}", message);
+    public ChatMessage handleMessage(@AuthenticationPrincipal Principal principal,
+            @Payload Map<String, String> payload) {
 
-        return message;
+        log.info("{} sent {}", principal.getName(), payload);
+
+        return new ChatMessage(principal.getName(), payload.get("message"));
     }
 }

--- a/src/main/java/fastcampus/websocketchat/dto/ChatMessage.java
+++ b/src/main/java/fastcampus/websocketchat/dto/ChatMessage.java
@@ -1,0 +1,14 @@
+package fastcampus.websocketchat.dto;
+
+
+public record ChatMessage
+(
+    String sender,
+    String message
+)
+
+
+{
+
+
+}

--- a/src/main/java/fastcampus/websocketchat/entity/Gender.java
+++ b/src/main/java/fastcampus/websocketchat/entity/Gender.java
@@ -1,0 +1,6 @@
+package fastcampus.websocketchat.entity;
+
+public enum Gender {
+    MALE, FEMALE
+
+}

--- a/src/main/java/fastcampus/websocketchat/entity/Member.java
+++ b/src/main/java/fastcampus/websocketchat/entity/Member.java
@@ -8,12 +8,16 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @Entity
+@Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "members")
@@ -25,13 +29,15 @@ public class Member {
     private Long id;
 
     private String email;
-    private String nickName;
+    private String nickname;
     private String name;
 
     @Enumerated(EnumType.STRING)
     private Gender gender;
     private String phoneNumber;
-    private LocalDateTime birthDay;
+    private LocalDate birthDay;
+
+    @Enumerated(EnumType.STRING)
     private Role role;
 
 

--- a/src/main/java/fastcampus/websocketchat/entity/Member.java
+++ b/src/main/java/fastcampus/websocketchat/entity/Member.java
@@ -1,0 +1,38 @@
+package fastcampus.websocketchat.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@Entity
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "members")
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long id;
+
+    private String email;
+    private String nickName;
+    private String name;
+
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+    private String phoneNumber;
+    private LocalDateTime birthDay;
+    private Role role;
+
+
+}

--- a/src/main/java/fastcampus/websocketchat/entity/Role.java
+++ b/src/main/java/fastcampus/websocketchat/entity/Role.java
@@ -1,0 +1,6 @@
+package fastcampus.websocketchat.entity;
+
+public enum Role {
+    ADMIN, USER
+
+}

--- a/src/main/java/fastcampus/websocketchat/repository/jpa/JpaMemberRepository.java
+++ b/src/main/java/fastcampus/websocketchat/repository/jpa/JpaMemberRepository.java
@@ -1,0 +1,10 @@
+package fastcampus.websocketchat.repository.jpa;
+
+import fastcampus.websocketchat.entity.Member;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaMemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByEmail(String email);
+}

--- a/src/main/java/fastcampus/websocketchat/service/CustomOAuthUserService.java
+++ b/src/main/java/fastcampus/websocketchat/service/CustomOAuthUserService.java
@@ -1,0 +1,56 @@
+package fastcampus.websocketchat.service;
+
+import fastcampus.websocketchat.entity.Gender;
+import fastcampus.websocketchat.entity.Member;
+import fastcampus.websocketchat.entity.Role;
+import fastcampus.websocketchat.repository.jpa.JpaMemberRepository;
+import fastcampus.websocketchat.vo.CustomOAuth2User;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CustomOAuthUserService extends DefaultOAuth2UserService {
+
+    private final JpaMemberRepository jpaMemberRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        Map<String, Object> attributeMap = oAuth2User.getAttribute("kakao_account");
+        String email = attributeMap.get("email").toString();
+        Member member = jpaMemberRepository.findByEmail(email).orElseGet(() ->
+                registerMember(attributeMap));
+
+        return new CustomOAuth2User(member, oAuth2User.getAttributes());
+    }
+
+    private Member registerMember(Map<String, Object> attributeMap) {
+         Member member = Member.builder()
+                .email((String)attributeMap.get("email"))
+                 .nickname((String) ((Map) attributeMap.get("profile")).get("nickname"))
+                .name(attributeMap.get("name").toString())
+                .phoneNumber(attributeMap.get("phone_number").toString())
+                .gender(Gender.valueOf(((String)attributeMap.get("gender")).toUpperCase()))
+                .birthDay(getBirthDay(attributeMap))
+                .role(Role.USER)
+                .build();
+
+        return jpaMemberRepository.save(member);
+    }
+
+    private LocalDate getBirthDay(Map<String, Object> attributeMap) {
+        String birthYear = attributeMap.get("birthyear").toString();
+        String birthDay = attributeMap.get("birthday").toString();
+
+        return LocalDate.parse(birthYear + birthDay, DateTimeFormatter.BASIC_ISO_DATE);
+    }
+}

--- a/src/main/java/fastcampus/websocketchat/vo/CustomOAuth2User.java
+++ b/src/main/java/fastcampus/websocketchat/vo/CustomOAuth2User.java
@@ -1,0 +1,34 @@
+package fastcampus.websocketchat.vo;
+
+import fastcampus.websocketchat.entity.Member;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@AllArgsConstructor
+@Getter
+public class CustomOAuth2User implements OAuth2User {
+
+    Member member;
+    Map<String, Object> attributeMap;
+
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return this.attributeMap;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(() -> member.getRole().name());
+    }
+
+    @Override
+    public String getName() {
+        return member.getNickname();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,7 +35,7 @@ spring:
               - gender
               - birthday
               - birthyear
-                phone_number
+              - phone_number
             redirect-uri: "http://localhost:8080/login/oauth2/code/kakao"
             client-name: kakao
             authorization-grant-type: authorization_code

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,15 +2,40 @@ spring:
   application:
     name: websocket-chat
 
+
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3308/chat_service
+    username: chat_service_user
+    password: chat_service_user
+
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+        highlight_sql: true
+        dialect: org.hibernate.dialect.MySQL8Dialect
+
+
   security:
     oauth2:
       client:
         registration:
           kakao:
-            client-id: d427c0410a48c5140c17e1a48d437148
-            client-secret: JRhzxNUj6SVWcbiaoMqdNhaAoqFEUuQO
+            client-id: b8c3ca6809a9218f5246f7e41092fca3
+            client-secret: C3nmNRLXuB4xCFTDcGJtcYHktsXr32bJ
             scope:
               - profile_nickname
+              - account_email
+              - name
+              - gender
+              - birthday
+              - birthyear
+                phone_number
             redirect-uri: "http://localhost:8080/login/oauth2/code/kakao"
             client-name: kakao
             authorization-grant-type: authorization_code

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -34,10 +34,6 @@
     <div class="col-md-12">
       <form class="form-inline">
         <div class="form-group">
-          <label for="username">Username</label>
-          <input type="text" id="username" class="form-control" placeholder="username to send">
-        </div>
-        <div class="form-group">
           <label for="send">Message</label>
           <input type="text" id="message" class="form-control" placeholder="message to send">
         </div>

--- a/src/main/resources/static/stomp.js
+++ b/src/main/resources/static/stomp.js
@@ -11,7 +11,7 @@ stompClient.onConnect = (frame) => {
   stompClient.publish({
     destination: "/pub/chats",
     body: JSON.stringify(
-        {'sender': $("#username").val(), 'message': "connected"})
+        {'message': "connected"})
   })
 };
 
@@ -49,7 +49,7 @@ function sendMessage() {
   stompClient.publish({
     destination: "/pub/chats",
     body: JSON.stringify(
-        {'sender': $("#username").val(), 'message': $("#message").val()})
+        {'message': $("#message").val()})
   });
   $("#message").val("")
 }


### PR DESCRIPTION
Member는 카카오로 회원 가입하면 DB에 저장된다.

저장된 Member의 닉네임을 가져와서 채팅 창 username에 나오도록 설정
-> DefaultOAuth2UserService 를 사용하면 이런 Custom된 id 를 사용할 수 없고, 무작위 16자리 숫자가 나온다.

따라서 OAuth2User 를 직접 구현하여 getName 메서드를 오버라이드 하여 커스텀해 구현한다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 채팅 메시지 처리 방식이 개선되어, 메시지 전송 시 발신자와 내용이 보다 명확하게 구분됩니다.
  - OAuth2 인증 프로세스가 강화되어, 카카오 계정으로 로그인 시 자동 회원 등록이 더욱 원활해졌습니다.
  - 데이터베이스 연결 지원 강화로 서비스 안정성이 향상되었습니다.
  
- **UI 변경**
  - 채팅 화면에서 불필요한 사용자 이름 입력란이 제거되어 인터페이스가 간소화되었습니다.
  - 메시지 전송 구조가 재정비되어 사용자 경험이 보다 직관적으로 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->